### PR TITLE
Change link text color to blue

### DIFF
--- a/src/pages/User/components/PullRequests/PullRequest/PullRequestInfo.js
+++ b/src/pages/User/components/PullRequests/PullRequest/PullRequestInfo.js
@@ -13,7 +13,7 @@ const PullRequestInfo = ({ pullRequest }) => (
       </a>{' '}
       submitted a pull request{' '}
       <a
-        className="text-orange link no-underline hover:underline"
+        className="text-blue-dark link no-underline hover:underline"
         href={pullRequest.html_url}
       >
         {pullRequest.repository_url.split('repos/')[1]}#{pullRequest.number}


### PR DESCRIPTION
## Issue

The red/orange text signifying the PR url makes it look like a dead link. So, changed the link color to a more traditional blue.

## Screenshot

**Before:**
<img width="1037" alt="Screen Shot 2019-10-22 at 09 21 00" src="https://user-images.githubusercontent.com/4490749/67257897-e03b1a00-f4ad-11e9-8b9d-c2740f93e8ce.png">

**After:**
<img width="1020" alt="Screen Shot 2019-10-22 at 09 21 07" src="https://user-images.githubusercontent.com/4490749/67257907-e7622800-f4ad-11e9-8879-48d035c6d2a1.png">
