### PR TITLE
Add information about Frogtoberfest in the homepage

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -3,7 +3,7 @@ import React from 'react';
 import presentedByLogo from '../assets/images/leapfrog-open-source-logo-1x.png';
 
 const Footer = () => (
-  <footer className="text-sm px-8 text-center flex-none py-4 w-3/4 sm:w-1/2 lg:w-1/3 mx-auto">
+  <footer className="text-sm px-8 text-center flex-none py-4 w-3/4 sm:w-1/2 lg:w-1/3 mx-auto mt-4">
     <a href="https://github.com/leapfrogtechnology/opensource">
       <img src={presentedByLogo} alt="Leapfrog Open Source Logo"></img>
     </a>

--- a/src/components/SiteDetails.js
+++ b/src/components/SiteDetails.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+const checklistItems = [
+  'Create 10 pull requests (PRs) between Oct 1-31.',
+  'PRs can be made to any public repository on GitHub.',
+  'PRs should not be labeled as `invalid`.',
+  'At least 4 PRs should be in repositories not owned by you.'
+];
+
+/**
+ * Component to show details about Frogtoberfest in the homepage.
+ */
+const SiteDetails = () => (
+  <div className="rounded mx-auto shadow w-3/4 sm:w-1/2 lg:w-1/3">
+    <div className="px-6 py-4">
+      <div className="font-bold mb-4">
+        <p className="text-lg mb-1">
+          Frogtoberfest, inspired from Hacktoberfest is a month-long open source
+          contribution challenge for Leapfroggers.
+        </p>
+      </div>
+      {checklistItems.map((item, index) => (
+        <li className="flex items-center mb-2" key={index}>
+          <div className="rounded-full fill-current text-green">
+            <svg
+              className="w-6 h-6 align-middle"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+              <polyline points="22 4 12 14.01 9 11.01"></polyline>
+            </svg>
+          </div>
+          <span className="text-gray-700 text-m ml-2">{item}</span>
+        </li>
+      ))}
+    </div>
+  </div>
+);
+
+export default SiteDetails;

--- a/src/components/UsernameForm/TimeMessage/getTimeMessage.js
+++ b/src/components/UsernameForm/TimeMessage/getTimeMessage.js
@@ -16,7 +16,7 @@ const getTimeMessage = () => {
   }
 
   if (daysLeft < 10) {
-    return `Only ${daysLeft} days left! You can do it!`;
+    return `Only ${daysLeft} days left. You can do it!`;
   }
 
   return `${daysLeft} days remaining!`;

--- a/src/components/UsernameForm/index.js
+++ b/src/components/UsernameForm/index.js
@@ -39,7 +39,7 @@ class UsernameForm extends Component {
   getUserUrl = username => `/user/${username}`;
 
   render = () => (
-    <div className="pb-4 md:pt-16">
+    <div className="pb-8 md:pt-16">
       <TimeMessage />
       <form
         action="/"

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -1,11 +1,14 @@
 import React, { Fragment } from 'react';
+
 import SiteTitle from '../../components/SiteTitle';
+import SiteDetails from '../../components/SiteDetails';
 import UsernameForm from '../../components/UsernameForm';
 
 const Home = () => (
   <Fragment>
     <SiteTitle>Frogtoberfest Checker</SiteTitle>
     <UsernameForm />
+    <SiteDetails />
   </Fragment>
 );
 

--- a/src/pages/User/components/PullRequests/MeLinkInfo.js
+++ b/src/pages/User/components/PullRequests/MeLinkInfo.js
@@ -11,7 +11,7 @@ export default class MeLinkInfo extends Component {
     localStorage.setItem('myGithub', this.props.username);
 
   render = () => (
-    <div className="rounded mx-auto mt-16 overflow-hidden w-5/6 lg:w-1/2 mt-4">
+    <div className="rounded mx-auto mt-8 overflow-hidden w-5/6 lg:w-1/2 mt-4">
       <button
         className="bg-blue-light text-blue-darker mx-auto mt-2 h-8 border-none pointer rounded-sm px-4 block saveUser"
         onClick={this.storeUsernameAsMe}


### PR DESCRIPTION
## Usage Changes

- A new component `SiteDetails` has been added
- Added steps for the Frogtoberfest challenge
- Have tweaked a few css classes in a few components

## Screenshot

**Desktop**
<br />
<img width="802" alt="Screen Shot 2019-10-23 at 5 56 35 PM" src="https://user-images.githubusercontent.com/4240991/67391506-8d04bc80-f5be-11e9-840b-6aa9307fa933.png">

**Mobile**
<br />
<img width="243" alt="Screen Shot 2019-10-23 at 5 56 47 PM" src="https://user-images.githubusercontent.com/4240991/67391508-8d04bc80-f5be-11e9-9387-29762b1c15b6.png">
