### PR TITLE
Fix Other Repository count still considering the "invalid" PRs 

### DIFF
--- a/src/pages/User/components/PullRequests/index.js
+++ b/src/pages/User/components/PullRequests/index.js
@@ -86,12 +86,13 @@ class PullRequests extends Component {
             })
           )
       );
-
-      const [data, userDetail] = await Promise.all(allResponses);
+      
+      const [responseData, userDetail] = await Promise.all(allResponses);
+      const data = this.getValidPullRequests(responseData);
       const count = this.counterOtherRepos(data, userDetail);
 
       this.setState({
-        data: this.getValidPullRequests(data),
+        data: data,
         userDetail,
         loading: false,
         otherReposCount: count,

--- a/src/pages/User/components/PullRequests/index.js
+++ b/src/pages/User/components/PullRequests/index.js
@@ -92,7 +92,7 @@ class PullRequests extends Component {
       const count = this.counterOtherRepos(data, userDetail);
 
       this.setState({
-        data: data,
+        data,
         userDetail,
         loading: false,
         otherReposCount: count,


### PR DESCRIPTION
## Issue
Even if invalid PR count in total count was not being counted, the other repo count was still being counted with invalid tag.

## Usage Changes
As other repo count value was counted before validation of data with invalid PR was counted, the other repo count still held count with invalid tag.

## Screenshot

Before:
![Screenshot from 2019-10-24 22-29-29](https://user-images.githubusercontent.com/15843175/67506978-c8ca7f80-f6ad-11e9-98bf-36436bd1992c.png)

After:
![Screenshot from 2019-10-24 22-29-56](https://user-images.githubusercontent.com/15843175/67507011-d7189b80-f6ad-11e9-984d-3c3a2c2aa32c.png)


