### PR TITLE
Open PR links in new tab

### DIFF
--- a/src/pages/User/components/PullRequests/PullRequest/PullRequestInfo.js
+++ b/src/pages/User/components/PullRequests/PullRequest/PullRequestInfo.js
@@ -9,7 +9,12 @@ const PullRequestInfo = ({ pullRequest }) => (
         {pullRequest.user.login}
       </a>{' '}
       submitted a pull request{' '}
-      <a className="text-blue-dark link no-underline hover:underline" href={pullRequest.html_url}>
+      <a
+        className="text-blue-dark link no-underline hover:underline"
+        target="_blank"
+        rel="noopener noreferrer"
+        href={pullRequest.html_url}
+      >
         {pullRequest.repository_url.split('repos/')[1]}#{pullRequest.number}
       </a>
     </div>


### PR DESCRIPTION
<!-- Have any questions? Read [CONTRIBUTING.md](https://github.com/leapfrogtechnology/frogtoberfest/blob/master/CONTRIBUTING.md) -->

## Issue
Resolves https://github.com/leapfrogtechnology/frogtoberfest/issues/29
The link of the pull request in the history section opens up in the same tab.

## Changes

Open links of PR in the history section in new tab

## Video
Check the live demo [here](https://drive.google.com/file/d/1m6GtkFHj0kT-CElgPnb4JCEYgKpdsja9/view).


