### PR TITLE
Frogtoberfest Completion Message Not Showing and Other Repo Invalid Count Still Being Counted

### DIFF
--- a/src/pages/User/components/PullRequests/index.js
+++ b/src/pages/User/components/PullRequests/index.js
@@ -180,13 +180,16 @@ class PullRequests extends Component {
    */
   displayPullRequests = userInfo => {
     const { data, userDetail } = userInfo;
-    const count = this.countOtherRepos(data, userDetail);
+    const validData = this.getValidPullRequests(data);
+    const otherReposCount = this.countOtherRepos(validData, userDetail);
+
+    this.props.setUserContributionCount(validData.items.length, otherReposCount);
 
     this.setState({
-      data: this.getValidPullRequests(data),
+      data: validData,
       userDetail,
       loading: false,
-      otherReposCount: count,
+      otherReposCount,
       error: null,
       isOrgMember: true
     });

--- a/src/pages/User/index.js
+++ b/src/pages/User/index.js
@@ -9,10 +9,21 @@ import PullRequests from './components/PullRequests';
  * User Component.
  */
 export class User extends Component {
-  state = {
-    totalPrCount: 0,
-    totalOtherPrCount: 0
-  };
+  /**
+   * User component constructor to set initial state.
+   *
+   * @param {*} props
+   */
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      totalPrCount: 0,
+      totalOtherPrCount: 0
+    };
+
+    this.setUserContributionCount = this.setUserContributionCount.bind(this);
+  }
 
   /**
    * Set user contribution count of pull requests and other pull request count.

--- a/src/pages/User/index.js
+++ b/src/pages/User/index.js
@@ -9,21 +9,10 @@ import PullRequests from './components/PullRequests';
  * User Component.
  */
 export class User extends Component {
-  /**
-   * User component constructor to set initial state.
-   *
-   * @param {*} props
-   */
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      totalPrCount: 0,
-      totalOtherPrCount: 0
-    };
-
-    this.setUserContributionCount = this.setUserContributionCount.bind(this);
-  }
+  state = {
+    totalPrCount: 0,
+    totalOtherPrCount: 0
+  };
 
   /**
    * Set user contribution count of pull requests and other pull request count.
@@ -63,7 +52,7 @@ export class User extends Component {
           totalPrCount={this.state.totalPrCount}
           totalOtherPrCount={this.state.totalOtherPrCount}
         />
-        <PullRequests username={username} setUserContributionCount={this.setUserContributionCount} />
+        <PullRequests username={username} setUserContributionCount={this.setUserContributionCount.bind(this)} />
       </Fragment>
     );
   }


### PR DESCRIPTION
## Issue
Although Frogtoberfest completion message showing based on condition was fixed recently, maybe due to some merge issue the message was not showing.

And again the invalid PR in other repos was still being counted.

## Usage Changes
For showing frogtoberfest completion message Binded setUserContributionCount to parent this.
For other repo invalid count still being counted, again validated the data before counted other repo count.

## Screenshot
Before:
![Screenshot from 2019-10-26 21-59-03](https://user-images.githubusercontent.com/15843175/67622646-df064600-f83b-11e9-8ed1-5e3c4b1ab67b.png)


After:
![Screenshot from 2019-10-26 21-53-09](https://user-images.githubusercontent.com/15843175/67622651-e62d5400-f83b-11e9-83e4-dbfd25dda177.png)


![Screenshot from 2019-10-26 21-53-22](https://user-images.githubusercontent.com/15843175/67622654-eaf20800-f83b-11e9-8d90-61ecbb87b21f.png)
