### PR TITLE
Enhance user experience on clicking 'this is me' button

### DIFF
--- a/src/pages/User/components/PullRequests/MeLinkInfo.js
+++ b/src/pages/User/components/PullRequests/MeLinkInfo.js
@@ -10,10 +10,13 @@ class MeLinkInfo extends Component {
     username: PropTypes.string.isRequired
   };
 
-  storeUsernameAsMe = () => localStorage.setItem('myGithub', this.props.username);
+  storeUsernameAsMe = () => {
+    localStorage.setItem('myGithub', this.props.username);
+    this.forceUpdate();
+  };
 
-  render = () => (
-    <div className="rounded mx-auto mt-8 overflow-hidden w-5/6 lg:w-1/2 mt-4">
+  render = () => {
+    let storeUsernameBtn = (
       <button
         className="bg-blue-light text-blue-darker mx-auto mt-2 h-8 border-none pointer rounded-sm px-4 block saveUser"
         onClick={this.storeUsernameAsMe}
@@ -21,6 +24,8 @@ class MeLinkInfo extends Component {
       >
         This is Me
       </button>
+    );
+    let infoStr = (
       <p className="text-grey-dark mx-auto text-center my-4">
         In the future, you can find your PRs by visiting{' '}
         <a href={`${HOSTNAME}/me`} className="link text-orange underline-hover saveUser" id="melink">
@@ -29,8 +34,30 @@ class MeLinkInfo extends Component {
         </a>{' '}
         on this device.
       </p>
-    </div>
-  );
+    );
+    const savedUsername = localStorage.getItem('myGithub');
+
+    if (savedUsername === this.props.username) {
+      storeUsernameBtn = null;
+      infoStr = (
+        <p className="text-mid-grey mx-auto text-center my-4">
+          Username {this.props.username} saved! You can visit{' '}
+          <a href={`${HOSTNAME}/me`} className="link saveUser" id="melink">
+            {HOSTNAME}
+            /me
+          </a>{' '}
+          now!
+        </p>
+      );
+    }
+
+    return (
+      <div className="rounded mx-auto mt-8 overflow-hidden w-5/6 lg:w-1/2 mt-4">
+        {storeUsernameBtn}
+        {infoStr}
+      </div>
+    );
+  };
 }
 
 const buttonStyle = {


### PR DESCRIPTION
## Issue

The 'This is Me' button was not telling what it is doing. It actually was saving current username into localStorage but it was always showing the same message i.e 'In the future, you can find your PRs by visiting...'
Now, when a user clicks that button, the button disappears and end-users gets a message called 'Username saved...'. 

## Usage Changes

N/A

## Screenshot
![frogtoberfest](https://user-images.githubusercontent.com/11685953/67703344-663df000-f9db-11e9-9b47-2b1ece51f02c.gif)

