### PR TITLE
Allow anyone to take part/view result in Frogtoberfest

### DIFF
--- a/src/components/SiteDetails.js
+++ b/src/components/SiteDetails.js
@@ -16,8 +16,8 @@ const SiteDetails = () => (
       <div className="px-6 py-4">
         <div className="font-bold mb-4">
           <p className="mb-4 leading-normal text-lg mb-1">
-            Frogtoberfest is a spin-off of Hacktoberfest; a month-long Open Source contribution challenge for
-            Leapfroggers.
+            Frogtoberfest is a spin-off of Hacktoberfest; a month-long Open Source contribution challenge for open
+            source enthusiast.
           </p>
         </div>
         <ul className="p-0">

--- a/src/pages/User/components/PullRequests/index.js
+++ b/src/pages/User/components/PullRequests/index.js
@@ -91,7 +91,8 @@ class PullRequests extends Component {
         error,
         loading: false,
         data: null,
-        userDetail: null
+        userDetail: null,
+        isOrgMember: true
       });
     }
   };
@@ -228,14 +229,16 @@ class PullRequests extends Component {
    */
   render = () => {
     const username = this.props.username;
-    const { loading, data, error, userDetail } = this.state;
+    const { loading, data, error, userDetail, isOrgMember } = this.state;
 
     if (loading) {
       return <LoadingIcon />;
     }
-    if (!this.state.isOrgMember) {
+
+    if (!isOrgMember) {
       return <ErrorText errorMessage={this.getNotAMemberMessage()} />;
     }
+
     if (error || data.errors || data.message) {
       return <ErrorText errorMessage={this.getErrorMessage()} />;
     }

--- a/src/pages/User/components/PullRequests/index.js
+++ b/src/pages/User/components/PullRequests/index.js
@@ -85,7 +85,7 @@ class PullRequests extends Component {
       const username = this.props.username;
       const userInfo = await fetchUserInfo(username);
 
-      !userInfo.membershipStatus ? this.showNotAMemberMessage() : this.displayPullRequests(userInfo);
+      this.displayPullRequests(userInfo);
     } catch (error) {
       this.setState({
         error,


### PR DESCRIPTION
## Issue
Previously only leapfrogger's were able to view frogtoberfest results/take part in frogtoberfest.

## Usage Changes
The limit such that only leafrogger could check the result/taka part has been removed.
For frogtoberfest 2021, anyone can take part in frogtoberfest 2021.
**(Note: This is part of Frogtoberfest 2021 finalized by the events team)**

## Screenshot
With design in #55 
![Screenshot from 2021-09-20 22-30-28](https://user-images.githubusercontent.com/15843175/134041951-afe17dfd-ab25-4f83-9d58-d5f47668b51f.png)

Without design in #55:
![Screenshot from 2021-09-20 22-35-48](https://user-images.githubusercontent.com/15843175/134042059-0e155b72-7a3e-4592-b7ff-e39ec567709f.png)




Update:
Fixed wording and wrong error message being displayed.

New view (without #55  design): 
![Screenshot from 2021-09-21 11-00-28](https://user-images.githubusercontent.com/15843175/134115252-fcd3deae-eb9a-4284-9ba3-4068a3e49c09.png)


![Screenshot from 2021-09-21 11-02-05](https://user-images.githubusercontent.com/15843175/134115298-b5290767-d692-4101-bf7e-a620460b4f77.png)
