### PR TITLE
Add support to extend deadline by specific amount of days additional to the days of october

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ REACT_APP_GA_CODE=YOUR_CODE
 
 # URL of the frontend React app
 REACT_APP_HOSTNAME=http://localhost:3000
+
+# Extended additional days other than those in the month of october
+REACT_APP_EXTENDED_DAYS=0

--- a/src/components/UsernameForm/TimeMessage/getTimeMessage.js
+++ b/src/components/UsernameForm/TimeMessage/getTimeMessage.js
@@ -1,7 +1,9 @@
+import { EXTENDED_DAYS } from 'config';
+
 const getTimeMessage = () => {
   const today = new Date();
   const currentMonth = today.getMonth();
-  const daysLeft = 31 - today.getDate();
+  const daysLeft = 31 - today.getDate() + EXTENDED_DAYS;
 
   if (currentMonth < 9) {
     const currentYear = today.getFullYear();

--- a/src/config.js
+++ b/src/config.js
@@ -4,3 +4,4 @@ export const TOTAL_PR_COUNT = 6;
 export const TOTAL_OTHER_PR_COUNT = 4;
 export const GITHUB_ORG_NAME = 'leapfrogtechnology';
 export const LF_CAREER_URL = 'https://www.lftechnology.com/careers/';
+export const EXTENDED_DAYS = parseInt(process.env.REACT_APP_EXTENDED_DAYS, 10) || 0;


### PR DESCRIPTION
## Issue
According to new announcement the deadline for frogtoberfest has been extended up to November 7. This change allows us to reflect the additional days in the checker.
![image](https://user-images.githubusercontent.com/44965674/196101786-666e41a0-0de8-470e-8a4b-8ac0434d8869.png)


## Usage Changes
Add value for  env variable `REACT_APP_EXTENDED_DAYS` as 7 for this year.

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/44965674/196101657-6f16e66c-25c2-4427-9bba-a548a231f1eb.png)


### After
![image](https://user-images.githubusercontent.com/44965674/196101733-3e222589-dbe4-41a4-9f61-c03d79016581.png)

