### PR TITLE
Update filter conditions for frogtoberfest 2022

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prettier:fix": "prettier --write \"{src,api,public}/**/*.{js,jsx,html,css,md,yml,yml,json}\" --loglevel warn"
   },
   "dependencies": {
+    "dayjs": "^1.11.5",
     "prop-types": "^15.6.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",

--- a/src/components/SiteDetails.js
+++ b/src/components/SiteDetails.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 const checklistItems = [
-  'Create 6 pull requests (PRs) between Oct 1-31.',
-  'At least 4 PRs should be in repositories not owned by you.',
+  'Create 6 pull requests (PRs) between Oct 1 - Nov 7.',
+  'At least 3 PRs should be in repositories not owned by you.',
   'PRs can be made to any public repository on GitHub.',
   'PRs should not be labeled as `invalid`.'
 ];

--- a/src/components/UsernameForm/TimeMessage/getTimeMessage.js
+++ b/src/components/UsernameForm/TimeMessage/getTimeMessage.js
@@ -1,7 +1,11 @@
+import dayjs from 'dayjs';
+
 const getTimeMessage = () => {
   const today = new Date();
   const currentMonth = today.getMonth();
-  const daysLeft = 31 - today.getDate();
+
+  const november8 = dayjs(`${today.getFullYear()}-11-08`);
+  const daysLeft = november8.diff(today, 'day');
 
   if (currentMonth < 9) {
     const currentYear = today.getFullYear();
@@ -9,7 +13,7 @@ const getTimeMessage = () => {
     return `Stay tuned for frogtoberfest ${currentYear} !!`;
   }
 
-  if (currentMonth > 9) {
+  if (november8.isBefore(today)) {
     return `Thank you for your participation. Stay tuned for Next Year !!`;
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 export const GITHUB_TOKEN = process.env.REACT_APP_GITHUB_TOKEN;
 export const HOSTNAME = process.env.REACT_APP_HOSTNAME;
 export const TOTAL_PR_COUNT = 6;
-export const TOTAL_OTHER_PR_COUNT = 4;
+export const TOTAL_OTHER_PR_COUNT = 3;
 export const GITHUB_ORG_NAME = 'leapfrogtechnology';
 export const LF_CAREER_URL = 'https://www.lftechnology.com/careers/';

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -30,7 +30,7 @@ export function getApiUrls(username) {
   const queryYear = getYear();
 
   return [
-    `https://api.github.com/search/issues?q=author:${username}+is:pr+created:${queryYear}-09-30T18:15:00..${queryYear}-10-31T18:15:00`,
+    `https://api.github.com/search/issues?q=author:${username}+is:pr+created:${queryYear}-09-30T18:15:00..${queryYear}-11-07T18:15:00`,
     `https://api.github.com/search/users?q=user:${username}`,
     `https://api.github.com/orgs/${GITHUB_ORG_NAME}/members/${username}`
   ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3094,6 +3094,11 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
+dayjs@^1.11.5:
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.5.tgz#00e8cc627f231f9499c19b38af49f56dc0ac5e93"
+  integrity sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION

## Issue
- Update filter conditions for frogtoberfest 2022

## Usage Changes
- Instead of 4 own PRs, its now required as only 3 own PRs
- The date has been changed from Oct 1 to Nov 7th and updated the countdown

## Screenshot
<img width="1677" alt="Screen Shot 2022-10-19 at 7 16 38 PM" src="https://user-images.githubusercontent.com/15843175/196705532-c160dd6b-7d03-4d84-ab93-d77835ea4865.png">
