### PR TITLE
Fix: Padding issue in the checker input field.

### DIFF
--- a/src/components/UsernameForm/UsernameInput.js
+++ b/src/components/UsernameForm/UsernameInput.js
@@ -14,7 +14,7 @@ const UsernameInput = ({ value, onChange }) => (
     autoCorrect="off"
     autoComplete="off"
     style={{ outline: 'none' }}
-    className="bn br--left leading-tight rounded-l flex-auto border-2 border-blue-lighter focus:border-blue-light border-r-0 text-grey-darkest"
+    className="bn br--left leading-tight rounded-l flex-auto border-2 border-blue-lighter focus:border-blue-light border-r-0 text-grey-darkest pl-4 pr-4"
   />
 );
 


### PR DESCRIPTION
## Description of the change

> In the PR, fix the padding issue in the input field of the GitHub checker to add left and right padding.

### Details of the changes

- [x] Add: left and right padding on checker input field. 


## Screenshot / Video

- Issue

![image](https://github.com/leapfrogtechnology/frogtoberfest/assets/53347572/c5705622-e3fb-413c-8c3a-7d2d228952a2)


- Fix

![image](https://github.com/leapfrogtechnology/frogtoberfest/assets/53347572/b9365acf-3229-40c7-a155-cab11140e533)


---
