### PR TITLE
fix: old twitter logo

### DIFF
--- a/src/pages/User/components/PullRequests/ShareButtons.js
+++ b/src/pages/User/components/PullRequests/ShareButtons.js
@@ -15,7 +15,7 @@ const ShareButtons = ({ username, pullRequestCount }) => {
           href={TWITTER_LINK}
           data-size="large"
         >
-          <i className="fab fa-twitter fa-lg mr-1 text-white" /> Twitter
+          <i className="fa-brands fa-x-twitter fa-lg mr-1 text-white" /> Twitter
         </a>
       </div>
       <div


### PR DESCRIPTION
## Description of the change

> Update Twitter's logo to a newer version.

### Details of the changes

- [x] Update: The Twitter logo is old. Modified to new "X" logo. 


## Screenshot / Video

- Issue:

![image](https://github.com/leapfrogtechnology/frogtoberfest/assets/53347572/288fa7ba-1174-4547-b7bb-3cdb0d7c6474)


- Fix: 
![image](https://github.com/leapfrogtechnology/frogtoberfest/assets/53347572/f912cead-50c4-4de3-9b1b-e73833077675)
