### PR TITLE
Fix: Circle plus icon "plus" symbol not being optically center

### DIFF
--- a/src/assets/scss/components/_accordion.scss
+++ b/src/assets/scss/components/_accordion.scss
@@ -47,5 +47,6 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		padding: 1px 0 0 1px;
 	}
 }


### PR DESCRIPTION
## Description of the change

> Fix the optical center issue with the plus symbol

### Details of the changes

- [x] Update: Plus icon to be optically centered in the "Circle plus" icon. 


## Screenshot / Video

- Issue: 

![image](https://github.com/leapfrogtechnology/frogtoberfest/assets/53347572/9c8bae73-e542-4459-b6fd-0c940db918ce)

- Fix:

![image](https://github.com/leapfrogtechnology/frogtoberfest/assets/53347572/191ede45-29f0-47e2-a7ba-afcfe3ea329e)
