### PR TITLE
fix: border to be added above and below

### DIFF
--- a/src/assets/scss/components/_accordion.scss
+++ b/src/assets/scss/components/_accordion.scss
@@ -5,11 +5,11 @@
 	.accordion-content {
 		overflow: hidden;
 		padding: 0 getSpacing('4x');
-		border-top: 1px solid getColor('primary.base');
+		border-bottom: 1px solid getColor('primary.base');
 		header {
 			padding-top: getSpacing('6x');
 			padding-bottom: getSpacing('4x');
-			
+
 			cursor: pointer;
 		}
 
@@ -33,6 +33,9 @@
 			height: 0;
 			font-size: 1rem;
 			transition: height 0.4s ease;
+		}
+		&:first-child{
+			border-top: 1px solid getColor('primary.base');
 		}
 	}
 


### PR DESCRIPTION
## Description of the change

> In the PR, fix the horizontal line not being present in the UI.

### Details of the changes

- [x] Fix: To have an bottom border as well for the first child element of the FAQ


## Screenshot / Video

- Issue: 

![image](https://github.com/leapfrogtechnology/frogtoberfest/assets/53347572/a260293f-34d8-41e1-b9d3-217763f2a3a4)


- Fix:

![image](https://github.com/leapfrogtechnology/frogtoberfest/assets/53347572/5cdfaf70-fbe4-482d-ba26-b63212b34770)
