### PR TITLE
fix: counter message not matching according to the criteria

### DIFF
--- a/src/pages/User/components/PullRequests/UserInfo/MotivationalMessage/getMessage.js
+++ b/src/pages/User/components/PullRequests/UserInfo/MotivationalMessage/getMessage.js
@@ -38,7 +38,7 @@ function getMessage(pullRequestCount, otherReposCount) {
     return "This year's result.";
   }
 
-  const isShowingOff = pullRequestCount > TOTAL_PR_COUNT && otherReposCount > TOTAL_OTHER_PR_COUNT;
+  const isShowingOff = pullRequestCount >= TOTAL_PR_COUNT && otherReposCount >= TOTAL_OTHER_PR_COUNT;
 
   if (isShowingOff) {
     return messages[messages.length - 1];


### PR DESCRIPTION
## Description of the change

> Message not matching the counter data.

### Details of the changes

- [x] Update: Condition to show the message according to change in counter to be "greater than equal to" instead of "greater than". 


## Screenshot / Video

- Issue:

![image](https://github.com/leapfrogtechnology/frogtoberfest/assets/53347572/b0f829cd-bffc-4581-b2df-4bed2bcb917a)

