### PR TITLE
fix: correct contributors numbers

### DIFF
--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -283,7 +283,7 @@ const Home = () => {
                 exclusive merch and
                 ribbiting perks for all your contributions</p>
               <ul className='has-bullet'>
-                <li>Top 15 contributors receive exclusive Frogtoberfest SWAG.</li>
+                <li>Top 20 contributors receive exclusive Frogtoberfest SWAG.</li>
                 <li>All eligible participants receive a digital certificate of participation.</li>
                 <li>Get featured on Leapfrog&apos;s social media and newsletters</li>
               </ul>
@@ -416,7 +416,7 @@ const Home = () => {
                     <li>Ensure all PRs are valid.</li>
                   </ol>
 
-                  Note: The top 15 contributors who fulfill these requirements will become eligible to receive the coveted Frogtoberfest SWAG as a token of recognition for their valuable contributions.
+                  Note: The top 20 contributors who fulfill these requirements will become eligible to receive the coveted Frogtoberfest SWAG as a token of recognition for their valuable contributions.
                 </p>
               </div>
               <div className="accordion-content">
@@ -427,7 +427,7 @@ const Home = () => {
                   <i className="icon fa-solid fa-plus ml-auto"></i>
                 </header>
                 <p className="accordion-content-description mr-lg-15x">
-                  The top 15 contributors and 10 Leapfroggers in the leaderboard who fulfill the criteria will become eligible to receive the coveted Frogtoberfest SWAG as a token of recognition for their valuable contributions.
+                  The top 20 contributors in the leaderboard who fulfill the criteria will become eligible to receive the coveted Frogtoberfest SWAG as a token of recognition for their valuable contributions.
                 </p>
               </div>
               <div className="accordion-content">


### PR DESCRIPTION
## Description of the change.

This PR updates the contributors numbers for 2024 event.

Changes made:
- Edits the hardcoded text wherever "15 contributors" mentioned to "20 contributors"
- Removes the mention of "10 Leapfroggers"

## How was this tested?

- Verified the sections where the numbers of contributors are shown.

## Test Evidences

![image](https://github.com/user-attachments/assets/b6b3ac8e-e45f-4f35-9350-919bf30ec999)
![image](https://github.com/user-attachments/assets/bfbb344b-0229-423a-812a-e420ba7e49a8)
![image](https://github.com/user-attachments/assets/88e4e498-f8db-4135-a123-50eec570bb9b)
