### PR TITLE
check scroll fix

### DIFF
--- a/src/assets/scss/layouts/_header.scss
+++ b/src/assets/scss/layouts/_header.scss
@@ -42,3 +42,9 @@
 		transform: translateY(0);
 	}
 }
+
+@media (max-width: 576px) {
+	.sticky {
+		position: fixed !important;
+	}
+}


### PR DESCRIPTION
## Description

The PR fixes the issue where the check page was auto scrolling to the top in mobile view after we scrolled down.
Changes:
- Sets header to fixed position in mobile view.

## Type of Change
- [x] Bug Fix

## How was this tested:
- Verified in the mobile view of Chrome browser

## Test Evidence

https://github.com/user-attachments/assets/a9a38541-5823-4652-ac98-0bf013a46549



