### PR TITLE
Fix grammatical issue in FAQ

### DIFF
--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -375,7 +375,7 @@ const Home = () => {
                   <i className="icon fa-solid fa-plus ml-auto"></i>
                 </header>
                 <p className="accordion-content-description mr-lg-15x">
-                  You have to fill up the registration form to be a verified participant for this challenge. In case you’ve not filled the form, you will not be included in the official leaderboard. As such, you you will not be eligible for the SWAG even if you pass the given criteria.</p>
+                  You have to fill up the registration form to be a verified participant for this challenge. In case you’ve not filled the form, you will not be included in the official leaderboard. As such, you will not be eligible for the SWAG even if you pass the given criteria.</p>
               </div>
 
               <div className="accordion-content">


### PR DESCRIPTION
## Description
Removed a duplicated "you" in the text to improve clarity and accuracy.

## Before

<img width="1471" alt="Screenshot 2024-10-28 at 11 13 44 AM" src="https://github.com/user-attachments/assets/43a9742a-3c8c-4d71-be08-1366ad892f61">

## After 
<img width="1479" alt="Screenshot 2024-10-28 at 11 15 58 AM" src="https://github.com/user-attachments/assets/533acd47-53da-4ccd-89e1-e21b58c968e8">


